### PR TITLE
trap soundcloud response errors

### DIFF
--- a/app/controllers/sounds_controller.rb
+++ b/app/controllers/sounds_controller.rb
@@ -8,7 +8,7 @@ class SoundsController < ApplicationController
   end
 
   def create
-    client = Soundcloud.new(client_id: 'ENV['SOUNDCLOUD_CLIENT_ID']')
+    client = Soundcloud.new(client_id: ENV['SOUNDCLOUD_CLIENT_ID'])
     @sound = Sound.new(sound_params)
     @song = Song.find(params[:song_id])
     track_url = @sound.track_url

--- a/app/controllers/sounds_controller.rb
+++ b/app/controllers/sounds_controller.rb
@@ -10,9 +10,17 @@ class SoundsController < ApplicationController
   def create
     client = Soundcloud.new(:client_id => ENV['SOUNDCLOUD_CLIENT_ID'])
     @sound = Sound.new(sound_params)
+    @song = Song.find(params[:song_id])
     track_url = @sound.track_url
-    embed_info = client.get('/oembed', :url => track_url)
-    @sound.embed_info = embed_info['html']
+
+    begin
+      embed_info = client.get('/oembed', :url => track_url)
+      @sound.embed_info = embed_info['html']
+    rescue SoundCloud::ResponseError
+      flash[:alert] = 'Problems saving sound'
+      render 'sounds/new' and return
+    end
+
     @sound.song_id = params['song_id']
 
     if @sound.save

--- a/app/controllers/sounds_controller.rb
+++ b/app/controllers/sounds_controller.rb
@@ -8,17 +8,17 @@ class SoundsController < ApplicationController
   end
 
   def create
-    client = Soundcloud.new(:client_id => ENV['SOUNDCLOUD_CLIENT_ID'])
+    client = Soundcloud.new(client_id: 'ENV['SOUNDCLOUD_CLIENT_ID']')
     @sound = Sound.new(sound_params)
     @song = Song.find(params[:song_id])
     track_url = @sound.track_url
 
     begin
-      embed_info = client.get('/oembed', :url => track_url)
+      embed_info = client.get('/oembed', url: 'track_url')
       @sound.embed_info = embed_info['html']
     rescue SoundCloud::ResponseError
       flash[:alert] = 'Problems saving sound'
-      render 'sounds/new' and return
+      render 'sounds/new' && return
     end
 
     @sound.song_id = params['song_id']


### PR DESCRIPTION
This PR fixes a bug where URLs that generate an error from soundcloud crash the app.