### PR TITLE
wrong hash syntax in API call

### DIFF
--- a/app/controllers/sounds_controller.rb
+++ b/app/controllers/sounds_controller.rb
@@ -8,15 +8,18 @@ class SoundsController < ApplicationController
   end
 
   def create
+    binding.pry
     client = Soundcloud.new(client_id: ENV['SOUNDCLOUD_CLIENT_ID'])
     @sound = Sound.new(sound_params)
     @song = Song.find(params[:song_id])
     track_url = @sound.track_url
 
     begin
-      embed_info = client.get('/oembed', url: 'track_url')
+      binding.pry
+      embed_info = client.get('/oembed', url: track_url)
       @sound.embed_info = embed_info['html']
     rescue SoundCloud::ResponseError
+      binding.pry
       flash[:alert] = 'Problems saving sound'
       render 'sounds/new' && return
     end
@@ -24,9 +27,11 @@ class SoundsController < ApplicationController
     @sound.song_id = params['song_id']
 
     if @sound.save
+      binding.pry
       flash[:success] = 'Sound saved successfully'
       redirect_to song_path(params['song_id'])
     else
+      binding.pry
       flash[:alert] = 'Problems saving sound'
       @errors = @sound.errors.full_messages
       render 'sounds/new'

--- a/app/controllers/sounds_controller.rb
+++ b/app/controllers/sounds_controller.rb
@@ -8,18 +8,15 @@ class SoundsController < ApplicationController
   end
 
   def create
-    binding.pry
     client = Soundcloud.new(client_id: ENV['SOUNDCLOUD_CLIENT_ID'])
     @sound = Sound.new(sound_params)
     @song = Song.find(params[:song_id])
     track_url = @sound.track_url
 
     begin
-      binding.pry
       embed_info = client.get('/oembed', url: track_url)
       @sound.embed_info = embed_info['html']
     rescue SoundCloud::ResponseError
-      binding.pry
       flash[:alert] = 'Problems saving sound'
       render 'sounds/new' && return
     end
@@ -27,11 +24,9 @@ class SoundsController < ApplicationController
     @sound.song_id = params['song_id']
 
     if @sound.save
-      binding.pry
       flash[:success] = 'Sound saved successfully'
       redirect_to song_path(params['song_id'])
     else
-      binding.pry
       flash[:alert] = 'Problems saving sound'
       @errors = @sound.errors.full_messages
       render 'sounds/new'


### PR DESCRIPTION
This PR fixes a syntax error that caused my soundcloud API calls to return response errors.